### PR TITLE
chore: update .gitignore with coverage and Claude CLI prompt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 node_modules/
 dist/
+coverage/
 .claude/
+
+# Prompts Claude CLI
+PALTA-CLAUDE.md
+PALTA-TEAMMATE-PROMPT.md
+PALTA-REVIEW-PROMPT.md
+open-source-proposals.md


### PR DESCRIPTION
## Summary

- Adiciona `coverage/` ao `.gitignore` para ignorar arquivos gerados pelos testes
- Adiciona arquivos de prompts do Claude CLI (`PALTA-CLAUDE.md`, `PALTA-TEAMMATE-PROMPT.md`, `PALTA-REVIEW-PROMPT.md`, `open-source-proposals.md`) ao `.gitignore`

## Test plan

- [ ] Verificar que `coverage/` não é rastreado pelo git após rodar os testes
- [ ] Verificar que os arquivos de prompt do Claude CLI não aparecem no `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)